### PR TITLE
Fix login URL path

### DIFF
--- a/applications/security/components/mixin_crud.py
+++ b/applications/security/components/mixin_crud.py
@@ -116,7 +116,7 @@ class PermissionMixin(object):
         if request.user.is_authenticated:
             return redirect('home')
 
-        return redirect('security:auth_login')
+        return redirect('security:signin')
 
     def _get_permissions_to_validate(self):
 

--- a/proy_clinico/settings.py
+++ b/proy_clinico/settings.py
@@ -149,7 +149,7 @@ MEDIA_URL = '/media/' # url de imagenes
 # https://docs.djangoproject.com/en/5.2/ref/settings/#default-auto-field
 
 AUTH_USER_MODEL = 'security.User'
-LOGIN_URL = '/auth/signin'
+LOGIN_URL = '/security/signin/'
 #SESSION_SERIALIZER = 'django.contrib.sessions.serializers.PickleSerializer'
 # SESSION_SERIALIZER = 'django.contrib.sessions.serializers.PickleSerializer'
 SESSION_SERIALIZER = 'django.contrib.sessions.serializers.JSONSerializer'


### PR DESCRIPTION
## Summary
- correct LOGIN_URL in settings
- fix PermissionMixin redirect to login

## Testing
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6844df87e1b883339933885f95c7d520