### PR TITLE
Fix group session check in PermissionMixin

### DIFF
--- a/applications/security/components/mixin_crud.py
+++ b/applications/security/components/mixin_crud.py
@@ -86,7 +86,8 @@ class PermissionMixin(object):
             user_session.set_group_session()
 
             if 'group_id' not in request.session:
-                return redirect('home')
+                messages.error(request, 'Usuario sin grupos asignados')
+                return redirect('security:signin')
 
             if user.is_superuser:
                 return super().get(request, *args, **kwargs)


### PR DESCRIPTION
## Summary
- redirect to security:signin when a user has no groups
- show an error message for users without assigned groups

## Testing
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6844e5a7a0f0833383c0693e37eb4dea