### PR TITLE
Handle logins for users without groups

### DIFF
--- a/applications/security/views/auth.py
+++ b/applications/security/views/auth.py
@@ -32,8 +32,16 @@ def signin(request):
             password = form.cleaned_data.get('password')
             user = authenticate(request, username=username, password=password)
             if user is not None:
-                login(request, user)
-                return redirect("home")
+                # Verificar que el usuario tenga grupos antes de iniciar sesión
+                if user.groups.exists():
+                    login(request, user)
+                    return redirect("home")
+                else:
+                    return render(request, "security/auth/signin.html", {
+                        "form": form,
+                        "error": "El usuario no tiene grupos asignados",
+                        **data
+                    })
             else:
                 return render(request, "security/auth/signin.html", {
                     "form": form,


### PR DESCRIPTION
## Summary
- require users to belong to a group before allowing login

## Testing
- `pip install -r dependencias.txt` *(fails: Tunnel connection failed)*
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6844e61b9dd083339b00be3633a135f8