### PR TITLE
Add Seguridad menu modules

### DIFF
--- a/applications/security/orm.py
+++ b/applications/security/orm.py
@@ -32,6 +32,12 @@ def populate():
     icon='bi bi-gear',
     order=4
     )
+
+    menu4 = Menu.objects.create(
+    name='Seguridad',
+    icon='bi bi-shield-lock',
+    order=5
+    )
     
     # Create Modules using bulk_create
     modules = [
@@ -56,12 +62,18 @@ def populate():
            description='Gestión de usuarios del sistema', icon='bi bi-people', order=1),
     Module(url='configuracion/', name='Configuración', menu=menu3, 
            description='Configuración general del sistema', icon='bi bi-sliders', order=2),
-    Module(url='reportes/', name='Reportes', menu=menu3, 
-           description='Generación de reportes y estadísticas', icon='bi bi-bar-chart', order=3)
+    Module(url='reportes/', name='Reportes', menu=menu3,
+           description='Generación de reportes y estadísticas', icon='bi bi-bar-chart', order=3),
+
+    # Modules for Seguridad menu
+    Module(url='security/menu_list/', name='Menus', menu=menu4,
+           description='Administración de menús', icon='bi bi-list', order=1),
+    Module(url='security/module_list/', name='Módulos', menu=menu4,
+           description='Administración de módulos', icon='bi bi-ui-checks', order=2)
     ]
-    
+
     created_modules = Module.objects.bulk_create(modules)
-    module1, module2, module3, module4, module5, module6, module7, module8, module9 = created_modules
+    module1, module2, module3, module4, module5, module6, module7, module8, module9, module10, module11 = created_modules
     
     # Create Users
     user1 = User.objects.create(
@@ -91,14 +103,18 @@ def populate():
     # Create Groups
     group_medicos = Group.objects.create(name='Médicos')
     group_asistentes = Group.objects.create(name='Asistentes')
+    group_admins = Group.objects.create(name='Administradores')
     
     # Add users to groups y si se usa set() se eliminan los grupos anteriores
     user1.groups.add(group_medicos)
     user2.groups.add(group_asistentes)
+    user1.groups.add(group_admins)
     
     # Create permissions for Patient and Diagnosis models only
     patient_ct = ContentType.objects.get(app_label='doctor', model='patient')
     diagnosis_ct = ContentType.objects.get(app_label='doctor', model='diagnosis')
+    menu_ct = ContentType.objects.get(app_label='security', model='menu')
+    module_ct = ContentType.objects.get(app_label='security', model='module')
     
     # Patient permissions.busca un objeto y, si no existe, lo crea automáticamente. Devueleve una tupla(objeto,encontrado).
     patient_view_tupla = Permission.objects.get_or_create(codename='view_patient', name='Can view Paciente', content_type=patient_ct)
@@ -112,10 +128,22 @@ def populate():
     diagnosis_add = Permission.objects.get_or_create(codename='add_diagnosis', name='Can add Diagnóstico', content_type=diagnosis_ct)[0]
     diagnosis_change = Permission.objects.get_or_create(codename='change_diagnosis', name='Can change Diagnóstico', content_type=diagnosis_ct)[0]
     diagnosis_delete = Permission.objects.get_or_create(codename='delete_diagnosis', name='Can delete Diagnóstico', content_type=diagnosis_ct)[0]
+
+    menu_view = Permission.objects.get_or_create(codename='view_menu', name='Can view Menu', content_type=menu_ct)[0]
+    menu_add = Permission.objects.get_or_create(codename='add_menu', name='Can add Menu', content_type=menu_ct)[0]
+    menu_change = Permission.objects.get_or_create(codename='change_menu', name='Can change Menu', content_type=menu_ct)[0]
+    menu_delete = Permission.objects.get_or_create(codename='delete_menu', name='Can delete Menu', content_type=menu_ct)[0]
+
+    module_view = Permission.objects.get_or_create(codename='view_module', name='Can view Module', content_type=module_ct)[0]
+    module_add = Permission.objects.get_or_create(codename='add_module', name='Can add Module', content_type=module_ct)[0]
+    module_change = Permission.objects.get_or_create(codename='change_module', name='Can change Module', content_type=module_ct)[0]
+    module_delete = Permission.objects.get_or_create(codename='delete_module', name='Can delete Module', content_type=module_ct)[0]
     
     # Add permissions to modules
     module1.permissions.add(patient_view, patient_add, patient_change, patient_delete)
     module5.permissions.add(diagnosis_view, diagnosis_add, diagnosis_change, diagnosis_delete)
+    module10.permissions.add(menu_view, menu_add, menu_change, menu_delete)
+    module11.permissions.add(module_view, module_add, module_change, module_delete)
     
     # Create GroupModulePermission records
     # For Médicos with Patient module
@@ -125,6 +153,12 @@ def populate():
     # For Médicos with Diagnosis module
     gmp2 = GroupModulePermission.objects.create(group=group_medicos, module=module5)
     gmp2.permissions.add(diagnosis_view, diagnosis_add, diagnosis_change)
+
+    gmp_admin_menu = GroupModulePermission.objects.create(group=group_admins, module=module10)
+    gmp_admin_menu.permissions.add(menu_view, menu_add, menu_change, menu_delete)
+
+    gmp_admin_module = GroupModulePermission.objects.create(group=group_admins, module=module11)
+    gmp_admin_module.permissions.add(module_view, module_add, module_change, module_delete)
     
     # For Asistentes with Patient module (limited permissions)
     gmp3 = GroupModulePermission.objects.create(group=group_asistentes, module=module1)

--- a/applications/security/orm25.py
+++ b/applications/security/orm25.py
@@ -32,6 +32,12 @@ def populate():
         icon='bi bi-gear',
         order=4
     )
+
+    menu4 = Menu.objects.create(
+        name='Seguridad',
+        icon='bi bi-shield-lock',
+        order=5
+    )
     
     # Create Modules using bulk_create
     modules = [
@@ -56,12 +62,18 @@ def populate():
                description='Gestión de usuarios del sistema', icon='bi bi-people', order=1),
         Module(url='configuracion/', name='Configuración', menu=menu3, 
                description='Configuración general del sistema', icon='bi bi-sliders', order=2),
-        Module(url='reportes/', name='Reportes', menu=menu3, 
-               description='Generación de reportes y estadísticas', icon='bi bi-bar-chart', order=3)
+        Module(url='reportes/', name='Reportes', menu=menu3,
+               description='Generación de reportes y estadísticas', icon='bi bi-bar-chart', order=3),
+
+        # Modules for Seguridad menu
+        Module(url='security/menu_list/', name='Menus', menu=menu4,
+               description='Administración de menús', icon='bi bi-list', order=1),
+        Module(url='security/module_list/', name='Módulos', menu=menu4,
+               description='Administración de módulos', icon='bi bi-ui-checks', order=2)
     ]
-    
+
     created_modules = Module.objects.bulk_create(modules)
-    module1, module2, module3, module4, module5, module6, module7, module8, module9 = created_modules
+    module1, module2, module3, module4, module5, module6, module7, module8, module9, module10, module11 = created_modules
     
     # Create Users ensuring hashed passwords
     user1 = User.objects.create_user(
@@ -91,14 +103,18 @@ def populate():
     # Create Groups
     group_medicos = Group.objects.create(name='Médicos')
     group_asistentes = Group.objects.create(name='Asistentes')
+    group_admins = Group.objects.create(name='Administradores')
     
     # Add users to groups y si se usa set() se eliminan los grupos anteriores
     user1.groups.add(group_medicos)
     user2.groups.add(group_asistentes)
+    user1.groups.add(group_admins)
     
     # Create permissions for Patient and Diagnosis models only
     patient_ct = ContentType.objects.get(app_label='doctor', model='patient')
     diagnosis_ct = ContentType.objects.get(app_label='doctor', model='diagnosis')
+    menu_ct = ContentType.objects.get(app_label='security', model='menu')
+    module_ct = ContentType.objects.get(app_label='security', model='module')
     
     # Patient permissions.busca un objeto y, si no existe, lo crea automáticamente. Devueleve una tupla(objeto,encontrado).
     patient_view_tupla = Permission.objects.get_or_create(codename='view_patient', name='Can view Paciente', content_type=patient_ct)
@@ -112,10 +128,22 @@ def populate():
     diagnosis_add = Permission.objects.get_or_create(codename='add_diagnosis', name='Can add Diagnóstico', content_type=diagnosis_ct)[0]
     diagnosis_change = Permission.objects.get_or_create(codename='change_diagnosis', name='Can change Diagnóstico', content_type=diagnosis_ct)[0]
     diagnosis_delete = Permission.objects.get_or_create(codename='delete_diagnosis', name='Can delete Diagnóstico', content_type=diagnosis_ct)[0]
+
+    menu_view = Permission.objects.get_or_create(codename='view_menu', name='Can view Menu', content_type=menu_ct)[0]
+    menu_add = Permission.objects.get_or_create(codename='add_menu', name='Can add Menu', content_type=menu_ct)[0]
+    menu_change = Permission.objects.get_or_create(codename='change_menu', name='Can change Menu', content_type=menu_ct)[0]
+    menu_delete = Permission.objects.get_or_create(codename='delete_menu', name='Can delete Menu', content_type=menu_ct)[0]
+
+    module_view = Permission.objects.get_or_create(codename='view_module', name='Can view Module', content_type=module_ct)[0]
+    module_add = Permission.objects.get_or_create(codename='add_module', name='Can add Module', content_type=module_ct)[0]
+    module_change = Permission.objects.get_or_create(codename='change_module', name='Can change Module', content_type=module_ct)[0]
+    module_delete = Permission.objects.get_or_create(codename='delete_module', name='Can delete Module', content_type=module_ct)[0]
     
     # Add permissions to modules
     module1.permissions.add(patient_view, patient_add, patient_change, patient_delete)
     module5.permissions.add(diagnosis_view, diagnosis_add, diagnosis_change, diagnosis_delete)
+    module10.permissions.add(menu_view, menu_add, menu_change, menu_delete)
+    module11.permissions.add(module_view, module_add, module_change, module_delete)
     
     # Create GroupModulePermission records
     # For Médicos with Patient module
@@ -125,6 +153,12 @@ def populate():
     # For Médicos with Diagnosis module
     gmp2 = GroupModulePermission.objects.create(group=group_medicos, module=module5)
     gmp2.permissions.add(diagnosis_view, diagnosis_add, diagnosis_change)
+
+    gmp_admin_menu = GroupModulePermission.objects.create(group=group_admins, module=module10)
+    gmp_admin_menu.permissions.add(menu_view, menu_add, menu_change, menu_delete)
+
+    gmp_admin_module = GroupModulePermission.objects.create(group=group_admins, module=module11)
+    gmp_admin_module.permissions.add(module_view, module_add, module_change, module_delete)
     
     # For Asistentes with Patient module (limited permissions)
     gmp3 = GroupModulePermission.objects.create(group=group_asistentes, module=module1)


### PR DESCRIPTION
## Summary
- extend ORM scripts with new 'Seguridad' menu and management modules
- seed Menu/Module permissions and admin group links

## Testing
- `python applications/security/orm.py` *(fails: No module named 'django')*
- `python manage.py test` *(fails: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684636d5a4748333ab64710199bac351